### PR TITLE
add updated usage of setTextAppearance

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
@@ -29,8 +29,13 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
 
     @Override
     public void configureUI(DataField dataField) {
-        getBinding().statsValue.setTextAppearance(getContext(), dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryValue : R.style.TextAppearance_OpenTracks_SecondaryValue);
-        getBinding().statsDescriptionMain.setTextAppearance(getContext(), dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryHeader : R.style.TextAppearance_OpenTracks_SecondaryHeader);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getBinding().statsValue.setTextAppearance(dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryValue : R.style.TextAppearance_OpenTracks_SecondaryValue);
+            getBinding().statsDescriptionMain.setTextAppearance(dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryHeader : R.style.TextAppearance_OpenTracks_SecondaryHeader);
+        } else {
+            getBinding().statsValue.setTextAppearance(getContext(), dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryValue : R.style.TextAppearance_OpenTracks_SecondaryValue);
+            getBinding().statsDescriptionMain.setTextAppearance(getContext(), dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryHeader : R.style.TextAppearance_OpenTracks_SecondaryHeader);
+        }
     }
 
     public static class Distance extends GenericStatisticsViewHolder {

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
@@ -3,6 +3,7 @@ package de.dennisguse.opentracks.viewmodels;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.os.Build;
 
 import androidx.core.content.ContextCompat;
 


### PR DESCRIPTION
**Describe the pull request**
Add a updated usage of setTextAppearance for android API versions >= 23. The old usage is retained for older API versions. 

**Link to the the issue**
https://github.com/rilling/OpenTracks-Concordia/issues/27

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
N/A
